### PR TITLE
Remove manual process management by using CommandContext()

### DIFF
--- a/ssh_session.go
+++ b/ssh_session.go
@@ -40,17 +40,17 @@ func createSSHSessionHandler(shell string) ssh.Handler {
 
 			cmd := exec.Command(s.Command()[0], s.Command()[1:]...)
 			// We use StdinPipe to avoid blocking on missing input
-			if stdIn, err := cmd.StdinPipe(); err != nil {
-				log.Println("Could not initialize StdInPipe", err)
+			if stdin, err := cmd.StdinPipe(); err != nil {
+				log.Println("Could not initialize stdinPipe", err)
 				s.Exit(1)
 				return
 			} else {
 				go func() {
-					if _, err := io.Copy(stdIn, s); err != nil {
-						log.Printf("Error while copying input from %s to stdIn: %s", s.RemoteAddr().String(), err)
+					if _, err := io.Copy(stdin, s); err != nil {
+						log.Printf("Error while copying input from %s to stdin: %s", s.RemoteAddr().String(), err)
 					}
-					if err := stdIn.Close(); err != nil {
-						log.Println("Error while closing stdInPipe:", err)
+					if err := stdin.Close(); err != nil {
+						log.Println("Error while closing stdinPipe:", err)
 					}
 				}()
 			}

--- a/ssh_session.go
+++ b/ssh_session.go
@@ -43,7 +43,7 @@ func createSSHSessionHandler(shell string) ssh.Handler {
 			// We use StdinPipe to avoid blocking on missing input
 			if stdin, err := cmd.StdinPipe(); err != nil {
 				log.Println("Could not initialize stdinPipe", err)
-				s.Exit(1)
+				s.Exit(255)
 				return
 			} else {
 				go func() {
@@ -65,10 +65,12 @@ func createSSHSessionHandler(shell string) ssh.Handler {
 				if err != nil {
 					log.Println("Command execution failed:", err)
 					io.WriteString(s, "Command execution failed: "+err.Error()+"\n")
-				} else {
-					log.Println("Command execution successful")
+					s.Exit(255)
+					return
 				}
+				log.Println("Command execution successful")
 				s.Exit(cmd.ProcessState.ExitCode())
+				return
 
 			case <-s.Context().Done():
 				log.Printf("Session terminated: %s", s.Context().Err())

--- a/ssh_session.go
+++ b/ssh_session.go
@@ -81,10 +81,9 @@ func createSSHSessionHandler(shell string) ssh.Handler {
 			log.Println("No PTY requested, no command supplied")
 
 			// Keep this open until the session exits, could e.g. be port forwarding
-			select {
-			case <-s.Context().Done():
-				log.Printf("Session terminated: %s", s.Context().Err())
-			}
+			<-s.Context().Done()
+			log.Printf("Session terminated: %s", s.Context().Err())
+			return
 		}
 	}
 }

--- a/ssh_session_unix.go
+++ b/ssh_session_unix.go
@@ -47,8 +47,14 @@ func createPty(s ssh.Session, shell string) {
 		}
 	}()
 
-	go io.Copy(f, s)
-	go io.Copy(s, f)
+	go func() {
+		io.Copy(f, s)
+		s.Close()
+	}()
+	go func() {
+		io.Copy(s, f)
+		s.Close()
+	}()
 
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()

--- a/ssh_session_unix.go
+++ b/ssh_session_unix.go
@@ -57,10 +57,12 @@ func createPty(s ssh.Session, shell string) {
 	case err := <-done:
 		if err != nil {
 			log.Println("Session ended with error:", err)
-		} else {
-			log.Println("Session ended normally")
+			s.Exit(255)
+			return
 		}
+		log.Println("Session ended normally")
 		s.Exit(cmd.ProcessState.ExitCode())
+		return
 
 	case <-s.Context().Done():
 		log.Printf("Session terminated: %s", s.Context().Err())

--- a/ssh_session_unix.go
+++ b/ssh_session_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // reverseSSH - a lightweight ssh server with a reverse connection feature

--- a/ssh_session_windows.go
+++ b/ssh_session_windows.go
@@ -127,8 +127,14 @@ func createPty(s ssh.Session, shell string) {
 		defer process.Kill()
 
 		// Link data streams of ssh session and conpty
-		go io.Copy(s, cpty.OutPipe())
-		go io.Copy(cpty.InPipe(), s)
+		go func() {
+			io.Copy(s, cpty.OutPipe())
+			s.Close()
+		}()
+		go func() {
+			io.Copy(cpty.InPipe(), s)
+			s.Close()
+		}()
 
 		done := make(chan struct {
 			*os.ProcessState

--- a/ssh_session_windows.go
+++ b/ssh_session_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 // reverseSSH - a lightweight ssh server with a reverse connection feature

--- a/ssh_session_windows.go
+++ b/ssh_session_windows.go
@@ -57,17 +57,17 @@ func createPty(s ssh.Session, shell string) {
 			CreationFlags: 0x08000000,
 		}
 		// We use StdinPipe to avoid blocking on missing input
-		if stdIn, err := cmd.StdinPipe(); err != nil {
-			log.Println("Could not initialize StdInPipe", err)
+		if stdin, err := cmd.StdinPipe(); err != nil {
+			log.Println("Could not initialize stdinPipe", err)
 			s.Exit(1)
 			return
 		} else {
 			go func() {
-				if _, err := io.Copy(stdIn, s); err != nil {
-					log.Printf("Error while copying input from %s to stdIn: %s", s.RemoteAddr().String(), err)
+				if _, err := io.Copy(stdin, s); err != nil {
+					log.Printf("Error while copying input from %s to stdin: %s", s.RemoteAddr().String(), err)
 				}
-				if err := stdIn.Close(); err != nil {
-					log.Println("Error while closing stdInPipe:", err)
+				if err := stdin.Close(); err != nil {
+					log.Println("Error while closing stdinPipe:", err)
 				}
 			}()
 		}


### PR DESCRIPTION
Golang provides the function exec.CommandContext(). Using this, a
`cancel()` function can be defered and dangling processes are cleaned up
automatically at function exit.

Using this the code can be simplified and all `select { }` constructs
waiting on processes can be removed.